### PR TITLE
Add BlessPlugin to force splitting large css files into multiple css

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "autoprefixer-loader": "^2.0.0",
     "availity-ekko": "^0.2.6",
+    "bless-webpack-plugin": "^1.0.0",
     "bower-webpack-plugin": "^0.1.8",
     "browser-sync": "^2.7.4",
     "chalk": "^1.0.0",

--- a/workflow/webpack/webpack-config.js
+++ b/workflow/webpack/webpack-config.js
@@ -3,6 +3,7 @@ var path = require('path');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var BowerWebpackPlugin = require('bower-webpack-plugin');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
+var BlessPlugin = require('bless-webpack-plugin');
 
 var pkg = require('../../package.json');
 
@@ -114,6 +115,10 @@ var config = {
       jQuery: 'jquery',
       'window.jQuery': 'jquery',
       _: 'lodash'
+    }),
+
+    new BlessPlugin({
+      imports:true
     }),
 
     new HtmlWebpackPlugin({


### PR DESCRIPTION
 This ensures selector length in conformance with IE < 10, ie less than or equal to 4095.
